### PR TITLE
Adjust for removal of IDBDatabaseException in Firefox nightlies.

### DIFF
--- a/IDBStore.js
+++ b/IDBStore.js
@@ -87,7 +87,13 @@
       }
 
 			openRequest.onerror = hitch(this, function(error){
-        if(error.target.errorCode == 12){ // TODO: Use const
+        var gotVersionErr = false;
+        if('error' in error.target) {
+          gotVersionErr = error.target.error.name == "VersionError";
+        } else if('errorCode' in error.target) {
+          gotVersionErr = error.target.errorCode == 12; // TODO: Use const
+        }
+        if(gotVersionErr){ 
           this.dbVersion++;
           setTimeout(hitch(this, 'openDB'));
         }else{


### PR DESCRIPTION
This makes my uses of IDBWrapper work in FF nightlies once more.
