### PR TITLE
autoContinue option, pass key to .put

### DIFF
--- a/idbstore.js
+++ b/idbstore.js
@@ -805,10 +805,9 @@
       cursorRequest.onsuccess = function (event) {
         var cursor = event.target.result;
         if (cursor) {
-          var next = cursor['continue'];
-          onItem(cursor.value, cursor, cursorTransaction, next);
+          onItem(cursor, cursorTransaction);
           if (options.autoContinue) {
-            next();
+            cursor['continue']()
           }
         } else {
           hasSuccess = true;


### PR DESCRIPTION
this unabstracts a couple of things:
- ability to control when the iterator iterates by passing `autoContinue: false` and then calling cursor.continue() manually (basically lets you control backpressure)
- ability to pass in a value to `.put` (it should still work the same if you just pass in a value also)
