### PR TITLE
Fix inheritance for IDBStore

### DIFF
--- a/idbstore.js
+++ b/idbstore.js
@@ -129,6 +129,11 @@
 
   IDBStore.prototype = /** @lends IDBStore */ {
 
+    // The prototype of a function naturally has a constructor property. Since
+    // this prototype is being replaced the constructor needs to be restored
+    // to allow inheritance.
+    constructor = IDBStore,
+
     /**
      * The version of IDBStore
      *


### PR DESCRIPTION
I found this because extending `IDBStore` with CoffeeScript doesn't work. Normally I would have used `_.extends` instead of replacing the prototype, but since nothing else depends on underscore I didn't want to add it.

Even if you aren't interested in CoffeeScript you can see that replacing the prototype breaks normal Javascript behavior.

```
var ConstructorA = function() {};
ConstructorA.prototype.test = function() {
    console.log("testing");
};

var ConstructorB = function() {};
ConstructorB.prototype = {
    test: function() {
        console.log('testing');
    }
};

// true: normal behavor
console.log(ConstructorA.prototype.constructor === ConstructorA);

// false: IDBStore's current behavior
console.log(ConstructorB.prototype.constructor === ConstructorB);
```
