### PR TITLE
Add paging capability to iterate method

### DIFF
--- a/idbstore.js
+++ b/idbstore.js
@@ -1010,6 +1010,10 @@
      *  iteration has ended
      * @param {Function} [options.onError=throw] A callback to be called
      *  if an error occurred during the operation.
+     * @param {Number} [options.pageSize] stop retrieving when this number of
+     *      records has been collected
+     * @param {Number} [options.pageNum] (1-based) skip "pageSize * (pageNum - 1)"
+     * 		number of records before starting to collect records
      * @returns {IDBTransaction} The transaction used for this operation.
      */
     iterate: function (onItem, options) {
@@ -1021,7 +1025,9 @@
         keyRange: null,
         writeAccess: false,
         onEnd: null,
-        onError: defaultErrorHandler
+        onError: defaultErrorHandler,
+        pageSize: 0,
+        pageNum: 0
       }, options || {});
 
       var directionType = options.order.toLowerCase() == 'desc' ? 'PREV' : 'NEXT';
@@ -1035,6 +1041,8 @@
       if (options.index) {
         cursorTarget = cursorTarget.index(options.index);
       }
+      var recordCount = 0;
+      var skipDone = false;
 
       cursorTransaction.oncomplete = function () {
         if (!hasSuccess) {
@@ -1055,9 +1063,23 @@
       cursorRequest.onsuccess = function (event) {
         var cursor = event.target.result;
         if (cursor) {
-          onItem(cursor.value, cursor, cursorTransaction);
-          if (options.autoContinue) {
-            cursor['continue']();
+          if (!skipDone && options.pageNum > 1 && options.pageSize > 0) {
+            var toSkip = (options.pageNum - 1) * options.pageSize;
+            cursor['advance'](toSkip);
+            skipDone = true;
+          } else {
+            onItem(cursor.value, cursor, cursorTransaction);
+            recordCount++;
+            if (options.autoContinue) {
+              if (options.pageSize > 0) {
+                if (recordCount < options.pageSize)
+                  cursor['continue']();
+                else
+                  hasSuccess = true;
+              } else {
+                cursor['continue']();
+              }
+            }
           }
         } else {
           hasSuccess = true;

--- a/test/idbwrapper_spec.js
+++ b/test/idbwrapper_spec.js
@@ -549,6 +549,59 @@ describe('IDBWrapper', function(){
 
     });
 
+    it('should fetch objects using basic index (KeyRange "all") and paging (page 1)', function(done){
+
+      store.query(function(data){
+        expect(data.length).to.equal(2);
+        expect(data[0].name).to.equal('Frank');
+        expect(data[1].name).to.equal('James');
+        done();
+      }, {
+        pageSize: 2,
+        pageNum: 1,
+        index: 'basic',
+        keyRange: store.makeKeyRange({
+          lower: ''
+        })
+      });
+
+    });
+
+    it('should fetch objects using basic index (KeyRange "all") and paging (page 2)', function(done){
+
+      store.query(function(data){
+        expect(data.length).to.equal(2);
+        expect(data[0].name).to.equal('Jenna');
+        expect(data[1].name).to.equal('Joe');
+        done();
+      }, {
+        pageSize: 2,
+        pageNum: 2,
+        index: 'basic',
+        keyRange: store.makeKeyRange({
+          lower: ''
+        })
+      });
+
+    });
+
+    it('should fetch objects using basic index (KeyRange "all") and paging (page 3)', function(done){
+
+      store.query(function(data){
+        expect(data.length).to.equal(2);
+        expect(data[0].name).to.equal('John');
+        expect(data[1].name).to.equal('John');
+        done();
+      }, {
+        pageSize: 2,
+        pageNum: 3,
+        index: 'basic',
+        keyRange: store.makeKeyRange({
+          lower: ''
+        })
+      });
+
+    });
 
     after(function(done){
       store.clear(function(){


### PR DESCRIPTION
Hi Jens, I am with GreatVines in Portland, USA. I used IDBWrapper to create a mock implementation of the Salesforce SmartStore (a database component in the Salesforce Mobile SDK). Since SmartStore is able to "paging" with a configurable page size, we added this capability to the IDBWrapper's iterate method. Maybe this feature could be added to IDBWrapper.

Peter
