### PR TITLE
Made deleteDatabase work and added callbacks

### DIFF
--- a/idbstore.js
+++ b/idbstore.js
@@ -393,9 +393,14 @@
      * Deletes the database used for this store if the IDB implementations
      * provides that functionality.
      */
-    deleteDatabase: function () {
+    deleteDatabase: function (onSuccess, onError) {
       if (this.idb.deleteDatabase) {
-        this.idb.deleteDatabase(this.dbName);
+        this.db.close();
+        var openRequest = this.idb.deleteDatabase(this.dbName);
+        openRequest.onsuccess = onSuccess;
+        openRequest.onerror = onError;
+      } else {
+        onError(new Error('Browser does not support IndexedDB deleteDatabase!'));
       }
     },
 

--- a/test/idbwrapper_spec.js
+++ b/test/idbwrapper_spec.js
@@ -1,5 +1,23 @@
 describe('IDBWrapper', function(){
 
+  describe('delete databases', function(){
+    var store;
+
+    before(function(done){
+      store = new IDBStore({
+        storeName: 'spec-store-simple'
+      }, done);
+    });
+
+    it('should delete the newly created database', function(done){
+      store.deleteDatabase(function(result){
+        expect(result).to.be.ok;
+        done();
+      }, done);
+    });
+
+  });
+
   describe('basic CRUD, in-line keys', function(){
 
     var store;


### PR DESCRIPTION
Hi Jens, I am with GreatVines in Portland, USA. I used IDBWrapper to create a mock implementation of the Salesforce SmartStore (a database component in the Salesforce Mobile SDK). Since SmartStore is able to delete "soups" (represented as stores in IndexedDB) we enhanced the IDBWrapper's deleteDatabase method to match the other methods in IDBWrapper (i.e. added success and fail callbacks). Also the database had to be closed before the delete succeeded. Maybe this feature could be added to IDBWrapper.

Peter