### PR TITLE
Added upsertBatch that delivers the records updated with auto-incremented key

### DIFF
--- a/idbstore.js
+++ b/idbstore.js
@@ -631,6 +631,85 @@
     },
 
     /**
+     * Like putBatch, takes an array of objects and stores them in a single
+     * transaction, but allows processing of the result values.  Returns the
+     * processed records containing the key for newly created records to the
+     * onSuccess calllback instead of only returning true or false for success.
+     * In addition, added the option for the caller to specify a key field that
+     * should be set to the newly created key.
+     *
+     * @param {Array} dataArray An array of objects to store
+     * @param {String} [options.keyField] Specifies a field in the record to update
+     *  with the auto-incrementing key
+     * @param {Function} [onSuccess] A callback that is called if all operations
+     *  were successful.
+     * @param {Function} [onError] A callback that is called if an error
+     *  occurred during one of the operations.
+     * @returns {IDBTransaction} The transaction used for this operation.
+     *
+     */
+    upsertBatch: function (dataArray, options, onSuccess, onError) {
+      onError || (onError = defaultErrorHandler);
+      onSuccess || (onSuccess = noop);
+
+      if (Object.prototype.toString.call(dataArray) != '[object Array]') {
+        onError(new Error('dataArray argument must be of type Array.'));
+      }
+      var batchTransaction = this.db.transaction([this.storeName], this.consts.READ_WRITE);
+      batchTransaction.oncomplete = function () {
+        if (hasSuccess) {
+          onSuccess(dataArray);
+        } else {
+          onError(false);
+        }
+      };
+      batchTransaction.onabort = onError;
+      batchTransaction.onerror = onError;
+
+      var keyField = options['keyField'];
+      var count = dataArray.length;
+      var called = false;
+      var hasSuccess = false;
+      var index = 0; // assume success callbacks are executed in order
+
+      var onItemSuccess = function (event) {
+        var record = dataArray[index++];
+        if (typeof keyField !== 'undefined')
+          record[keyField] = event.target.result;
+
+        count--;
+        if (count === 0 && !called) {
+          called = true;
+          hasSuccess = true;
+        }
+      };
+
+      dataArray.forEach(function (record) {
+        var key = record.key;
+
+        var onItemError = function (err) {
+          batchTransaction.abort();
+          if (!called) {
+            called = true;
+            onError(err);
+          }
+        };
+
+        var putRequest;
+        if (this.keyPath !== null) { // in-line keys
+          this._addIdPropertyIfNeeded(record);
+          putRequest = batchTransaction.objectStore(this.storeName).put(record);
+        } else { // out-of-line keys
+          putRequest = batchTransaction.objectStore(this.storeName).put(record, key);
+        }
+        putRequest.onsuccess = onItemSuccess;
+        putRequest.onerror = onItemError;
+      }, this);
+
+      return batchTransaction;
+    },
+
+    /**
      * Takes an array of keys and removes matching objects in a single
      * transaction.
      *

--- a/test/idbwrapper_spec.js
+++ b/test/idbwrapper_spec.js
@@ -211,6 +211,49 @@ describe('IDBWrapper', function(){
 
   });
 
+  describe('batch ops - upsertBatch', function(){
+
+    var store;
+    var dataArray = [
+      {
+        name: 'John'
+      },
+      {
+        name: 'Joe'
+      },
+      {
+        name: 'James'
+      }
+    ];
+
+    before(function(done){
+      store = new IDBStore({
+        storeName: 'spec-store-simple'
+      }, done);
+    });
+
+
+    it('should store multiple objects and add keys to these objects', function(done){
+      var options = { keyField: 'id' };
+      store.upsertBatch(dataArray, options, function(data){
+        expect(data[0].name).to.equal('John');
+        expect(data[1].name).to.equal('Joe');
+        expect(data[2].name).to.equal('James');
+        expect(data[0].id).to.exist;
+        expect(data[1].id).to.exist;
+        expect(data[2].id).to.exist;
+        done();
+      }, done);
+    });
+
+    after(function(done){
+      store.clear(function(){
+        done();
+      });
+    });
+
+  });
+
   describe('getBatch() dataArray return type', function(){
 
     var store;


### PR DESCRIPTION
Hi Jens, I am with GreatVines in Portland, USA. We used IDBWrapper to create a mock implementation of the Salesforce SmartStore (a database component in the Salesforce Mobile SDK). Since SmartStore returns the records upon completion of an upsert operation, we added a new method to IDBStore called upsertBatch. Optionally you can request this method to update a field in the record to contain the auto-generated key. We decided on a new method instead of enhancing putBatch since putBatch returns a true/false result instead of the records.  Maybe this new method could be added to IDBWrapper.

Peter