### PR TITLE
Capability to detect whether a database already exists without creating it

### DIFF
--- a/test/idbwrapper_spec.js
+++ b/test/idbwrapper_spec.js
@@ -1,5 +1,26 @@
 describe('IDBWrapper', function(){
 
+  describe('check for existing database', function(){
+
+    it('should report the database does not exist', function(done){
+      var cancelMsg = "Database does not exist";
+      var count = 0;
+      var onError = function(err) {
+        if (count++ === 0) {
+          expect(err).to.equal(cancelMsg);
+        } else {
+          done();
+        }
+      }
+      store = new IDBStore({
+        storeName: 'spec-store-simple',
+        onError: onError,
+        cancelIfNew: true,
+        cancelMsg: cancelMsg
+      }, done);
+    });
+  });
+
   describe('basic CRUD, in-line keys', function(){
 
     var store;


### PR DESCRIPTION
Hi Jens, I am with GreatVines in Portland, USA. We used IDBWrapper to create a mock implementation of the Salesforce SmartStore (a database component in the Salesforce Mobile SDK). Since SmartStore allows you to check for the physical presence of a "soup" (represented as a store in IndexedDB) without creating it, we added the capability to the openDB method to abort the transaction if the intent is to only check whether a database exists (without actually creating it). See the added cancelIfNew and CancelMsg options.  Maybe this feature could be added to IDBWrapper.

Peter
