### PR TITLE
added IndexedDBShim detection closes #58

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ IDBWrapper works on all browsers supporting the IndexedDB API, which are:
 * IE10
 * IE10 for WP8
 
+If using in an older browser supporting WebSql along with [IndexedDBShim](https://github.com/axemclion/IndexedDBShim), IndexedDBShim needs to run first.
+
 ##Tutorials
 
 There are two tutorials to get you up and running:

--- a/idbstore.js
+++ b/idbstore.js
@@ -114,7 +114,7 @@
     onStoreReady && (this.onStoreReady = onStoreReady);
 
     var env = typeof window == 'object' ? window : self;
-    this.idb = env.indexedDB || env.webkitIndexedDB || env.mozIndexedDB;
+    this.idb = env.indexedDB || env.webkitIndexedDB || env.mozIndexedDB || env.shimIndexedDB;
     this.keyRange = env.IDBKeyRange || env.webkitIDBKeyRange || env.mozIDBKeyRange;
 
     this.features = {


### PR DESCRIPTION
This can be handy if you have to use the IndexedDBShim.

Eg iOS 8 homescreen mode where window.indexedDB is null + readonly!