### PR TITLE
add lib/ to .npmignore (to ignore 5mb google closure jar)

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@
 .git*
 node_modules
 test/polyfills
+lib/


### PR DESCRIPTION
I noticed that the idb-wrapper tarball was taking forever to npm install on some slow internet, so I checked it out and noticed that the `lib/closure` folder has a 5.3mb `compiler.jar` file that seems to be a devDependency