### PR TITLE
Support `shimIndexedDB`

### DIFF
--- a/idbstore.js
+++ b/idbstore.js
@@ -115,7 +115,7 @@
     onStoreReady && (this.onStoreReady = onStoreReady);
 
     var env = typeof window == 'object' ? window : self;
-    this.idb = env.indexedDB || env.webkitIndexedDB || env.mozIndexedDB || env.shimIndexedDB;
+    this.idb = env.shimIndexedDB || env.indexedDB || env.webkitIndexedDB || env.mozIndexedDB || env.shimIndexedDB;
     this.keyRange = env.IDBKeyRange || env.webkitIDBKeyRange || env.mozIDBKeyRange;
 
     this.features = {

--- a/idbstore.js
+++ b/idbstore.js
@@ -115,7 +115,7 @@
     onStoreReady && (this.onStoreReady = onStoreReady);
 
     var env = typeof window == 'object' ? window : self;
-    this.idb = env.shimIndexedDB || env.indexedDB || env.webkitIndexedDB || env.mozIndexedDB || env.shimIndexedDB;
+    this.idb = env.shimIndexedDB || env.indexedDB || env.webkitIndexedDB || env.mozIndexedDB;
     this.keyRange = env.IDBKeyRange || env.webkitIDBKeyRange || env.mozIDBKeyRange;
 
     this.features = {


### PR DESCRIPTION
Important because for example safari doesn't allow overwriting this (see https://github.com/axemclion/IndexedDBShim), useful for cordova apps.