### PR TITLE
Adding return to iterate.onItem to increment "recordCount" only if it  returns "undefined" (keep compatibility) or "true".

### DIFF
--- a/idbstore.js
+++ b/idbstore.js
@@ -1146,6 +1146,8 @@
      *  results to this number
      * @param {Number} [options.offset=0] Skip the provided number of results
      *  in the resultset
+     * @param {Boolean} [options.allowItemRejection=false] Allows the onItem 
+	 * function to return a Boolean to accept or reject the current item
      * @returns {IDBTransaction} The transaction used for this operation.
      */
     iterate: function (onItem, options) {
@@ -1159,7 +1161,8 @@
         onEnd: null,
         onError: defaultErrorHandler,
         limit: Infinity,
-        offset: 0
+        offset: 0,
+		allowItemRejection: false
       }, options || {});
 
       var directionType = options.order.toLowerCase() == 'desc' ? 'PREV' : 'NEXT';
@@ -1199,7 +1202,7 @@
             options.offset = 0;
           } else {
             var onItemReturn = onItem(cursor.value, cursor, cursorTransaction);
-			if (onItemReturn === undefined || onItemReturn) {
+			if (!options.allowItemRejection || onItemReturn) {
 				recordCount++;
 			}
             if (options.autoContinue) {

--- a/idbstore.js
+++ b/idbstore.js
@@ -1198,8 +1198,10 @@
             cursor.advance(options.offset);
             options.offset = 0;
           } else {
-            onItem(cursor.value, cursor, cursorTransaction);
-            recordCount++;
+            var onItemReturn = onItem(cursor.value, cursor, cursorTransaction);
+			if (onItemReturn === undefined || onItemReturn) {
+				recordCount++;
+			}
             if (options.autoContinue) {
               if (recordCount + options.offset < options.limit) {
                 cursor['continue']();

--- a/test/idbwrapper_spec.js
+++ b/test/idbwrapper_spec.js
@@ -781,4 +781,86 @@ describe('IDBWrapper', function(){
 
   });
 
+  describe('iterate with allowItemRejection=true', function(){
+
+    var store;
+
+    before(function(done){
+      store = new IDBStore({
+        storeName: 'spec-store-simple'
+      }, function(){
+
+        var dataArray = [
+          {
+            id: 1,
+            name: 'John'
+          },
+          {
+            id: 2,
+            name: 'Joe'
+          },
+          {
+            id: 3,
+            name: 'Joseph'
+          },
+          {
+            id: 4,
+            name: 'Chloe'
+          }
+		];
+
+        store.putBatch(dataArray, function(){
+          done();
+        });
+
+      });
+    });
+
+    it('should return only Joe and Chloe', function(done){
+	  var results = [];
+	  var onItem = function(item) {
+	    if (item.name.toLowerCase().indexOf('oe') >= 0) {
+		  results.push(item);
+		  return true;
+		}
+		return false;
+	  };
+	  var options = {
+	    allowItemRejection: true,
+		writeAccess: false,
+		onEnd: function() {
+		  expect(results.length).to.equal(2);
+		  expect(results[0].id).to.equal(2);
+		  expect(results[1].id).to.equal(4);
+	      done();
+		}
+	  };
+      store.iterate(onItem, options);
+    });
+	
+    it('should return only John and Joe', function(done){
+	  var results = [];
+	  var onItem = function(item) {
+	    if (item.name.toLowerCase().startsWith('jo') >= 0) {
+		  results.push(item);
+		  return true;
+		}
+		return false;
+	  };
+	  var options = {
+	    allowItemRejection: true,
+		writeAccess: false,
+		limit: 2,
+		onEnd: function() {
+		  expect(results.length).to.equal(2);
+		  expect(results[0].id).to.equal(1);
+		  expect(results[1].id).to.equal(2);
+	      done();
+		}
+	  };
+      store.iterate(onItem, options);
+    });
+	
+  });
+
 });


### PR DESCRIPTION
Because IndexedDB is limited on filtering, I had to use iterate and manually check each item with custom filters.
But I still need to limit the quantity of records returned, so I don't iterate the whole store, I know that there is the param "limit" the problem is that IDBWrapper doesn't know how many records passed my filter.
To solve this, I changed the "onItem" function to return a boolean and increment "recordCount" only if it returns "undefined" (keep compatibility) or "true".