### PR TITLE
Handle IDB open error event

### DIFF
--- a/idbstore.js
+++ b/idbstore.js
@@ -1388,9 +1388,9 @@
 
     function hasVersionError(errorEvent) {
         if ('error' in errorEvent.target) {
-            return event.target.error.name == 'VersionError';
+            return errorEvent.target.error.name == 'VersionError';
         } else if ('errorCode' in errorEvent.target) {
-            return event.target.errorCode == 12;
+            return errorEvent.target.errorCode == 12;
         }
         return false;
     }

--- a/idbstore.js
+++ b/idbstore.js
@@ -284,18 +284,21 @@
             var openRequest = this.idb.open(this.dbName, this.dbVersion);
             var preventSuccessCallback = false;
 
-            openRequest.onerror = function (error) {
+            openRequest.onerror = function (errorEvent) {
 
-                var gotVersionErr = false;
-                if ('error' in error.target) {
-                    gotVersionErr = error.target.error.name == 'VersionError';
-                } else if ('errorCode' in error.target) {
-                    gotVersionErr = error.target.errorCode == 12;
-                }
-
-                if (gotVersionErr) {
+                if (hasVersionError(errorEvent)) {
                     this.onError(new Error('The version number provided is lower than the existing one.'));
                 } else {
+                    var error;
+
+                    if (errorEvent.target.error) {
+                        error = errorEvent.target.error;
+                    } else {
+                        var errorMessage = 'IndexedDB unknown error occurred when opening DB ' + this.dbName + ' version ' + this.dbVersion;
+                        if ('errorCode' in errorEvent.target) errorMessage += ' with error code ' + errorEvent.target.errorCode;
+                        error = new Error(errorMessage);
+                    }
+
                     this.onError(error);
                 }
             }.bind(this);
@@ -1381,6 +1384,15 @@
             }
         }
         return target;
+    }
+
+    function hasVersionError(errorEvent) {
+        if ('error' in errorEvent.target) {
+            return event.target.error.name == 'VersionError';
+        } else if ('errorCode' in errorEvent.target) {
+            return event.target.errorCode == 12;
+        }
+        return false;
     }
 
     IDBStore.prototype = proto;


### PR DESCRIPTION
Enhanced the error handling to handle cases outside of version mismatches. If an error occurs when opening a connection to IDB, the object that is propagated out to the caller is an Event instead of an Error. This will ensure that an actual Error is thrown instead of throwing the Event object.